### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/21/ConnectingApps.IntegrationFixtureTests21.NuGet/ConnectingApps.IntegrationFixtureTests21.NuGet.csproj
+++ b/21/ConnectingApps.IntegrationFixtureTests21.NuGet/ConnectingApps.IntegrationFixtureTests21.NuGet.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="Refit" Version="5.1.67" />
-    <PackageReference Include="ConnectingApps.IntegrationFixture" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Moq" Version="4.14.3" />
+    <PackageReference Include="Refit" Version="5.2.1" />
+    <PackageReference Include="ConnectingApps.IntegrationFixture" Version="2.1.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@DaanAcohen, I found an issue in the ConnectingApps.IntegrationFixtureTests21.NuGet.csproj:

Packages Microsoft.AspNetCore.Mvc.Testing v2.1.3, Microsoft.NET.Test.Sdk v16.6.1, Moq v4.14.1, Refit v5.1.67, ConnectingApps.IntegrationFixture v2.1.6 and xunit.runner.visualstudio v2.4.1 transitively introduce 200 dependencies into DncWireMockDemo’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/DncWireMockDemo.html)), while Microsoft.AspNetCore.Mvc.Testing v2.2.0, Microsoft.NET.Test.Sdk v16.10.0, Moq v4.14.3, Refit v5.2.1, ConnectingApps.IntegrationFixture v2.1.7 and xunit.runner.visualstudio v2.4.3 can only introduce 173 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/DncWireMockDemo_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose